### PR TITLE
refactor: centralizar URL del backend en constante API_BASE_URL

### DIFF
--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -1,6 +1,7 @@
 import { boot } from "quasar/wrappers";
 import axios, { AxiosInstance } from "axios";
 import { LocalStorage } from "quasar";
+import { API_BASE_URL } from '../constants/api';
 
 declare module "@vue/runtime-core" {
   interface ComponentCustomProperties {
@@ -16,11 +17,11 @@ declare module "@vue/runtime-core" {
 // "export default () => {}" function below (which runs individually
 // for each client)
 const apiNoAuth = axios.create({
-  baseURL: "https://platamx-backend-1cvg.onrender.com/",
+  baseURL: `${API_BASE_URL}/`,
 });
 
 const apiAuth = () => {
-  const baseURL = `https://platamx-backend-1cvg.onrender.com/`;
+  const baseURL = `${API_BASE_URL}/`;
 
   const http = axios.create({ baseURL });
 

--- a/src/boot/collections.ts
+++ b/src/boot/collections.ts
@@ -1,10 +1,11 @@
 import { boot } from 'quasar/wrappers';
 import axios from 'axios';
 import { globalCollections } from '../stores/globalCollections';
+import { API_BASE_URL } from '../constants/api';
 
 export default boot(async () => {
   try {
-    const url = "https://platamx-backend-1cvg.onrender.com/collections?page=1&items=25";
+    const url = `${API_BASE_URL}/collections?page=1&items=25`;
     const { data: response } = await axios.get(url);
     
     globalCollections.value = response.data.map((e: any) => ({

--- a/src/components/CreateAccount.vue
+++ b/src/components/CreateAccount.vue
@@ -106,6 +106,7 @@ import { useI18n } from 'vue-i18n';
 
 import validationRules from "../rules";
 import { getBackendError } from "../utils/error";
+import { API_BASE_URL } from "../constants/api";
 
 const { t } = useI18n();
 const rules = validationRules(t);
@@ -191,7 +192,7 @@ async function createAccount() {
   try {
     createAccountButton.value?.setAttribute("disabled", "");
     loading.value = true;
-    const url = "https://platamx-backend-1cvg.onrender.com/users";
+    const url = `${API_BASE_URL}/users`;
 
     await axios.post(url, user.value);
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -81,6 +81,7 @@ import axios from "axios";
 import { useI18n } from 'vue-i18n';
 
 import validationRules from "../rules";
+import { API_BASE_URL } from "../constants/api";
 import { getBackendError } from "../utils/error";
 
 const { t } = useI18n();
@@ -157,7 +158,7 @@ async function login() {
   try {
     loginButton.value?.setAttribute("disabled", "");
     loading.value = true;
-    const url = "https://platamx-backend-1cvg.onrender.com/auth/login";
+    const url = `${API_BASE_URL}/auth/login`;
 
     const data = {
       email: email.value,

--- a/src/components/TopProducts.vue
+++ b/src/components/TopProducts.vue
@@ -28,6 +28,7 @@
 import axios from "axios";
 import { ref } from "vue";
 import { useI18n } from 'vue-i18n';
+import { API_BASE_URL } from "../constants/api";
 
 import ProductCard from "../components/ProductCard.vue";
 import { globalCollections } from "../stores/globalCollections";
@@ -49,7 +50,7 @@ async function getProductsByCollection(collectionID: number) {
   try {
     loading.value = true;
     productsByCollection.value = [null, null, null];
-    const url = `https://platamx-backend-1cvg.onrender.com/products?page=1&items=10&collestionsIds=${collectionID}`;
+    const url = `${API_BASE_URL}/products?page=1&items=10&collestionsIds=${collectionID}`;
     const { data: response } = await axios.get(url);
     productsByCollection.value = response.data;
     loading.value = false;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'https://platamx-backend-1cvg.onrender.com';

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -127,6 +127,7 @@ import { useQuasar, useMeta } from "quasar";
 
 import validationRules from "../rules";
 import { apiAuth } from "../boot/axios";
+import { API_BASE_URL } from "../constants/api";
 
 import ShopBag from "../components/icons/ShopBag.vue";
 import Account from "../components/icons/Account.vue";
@@ -348,7 +349,7 @@ async function login() {
   try {
     loginButton.value?.setAttribute("disabled", "");
     loading.value = true;
-    const url = "https://platamx-backend-1cvg.onrender.com/auth/login";
+    const url = `${API_BASE_URL}/auth/login`;
 
     const data = {
       email: email.value,
@@ -446,7 +447,7 @@ async function createAccount() {
   try {
     createAccountButton.value?.setAttribute("disabled", "");
     loading.value = true;
-    const url = "https://platamx-backend-1cvg.onrender.com/users";
+    const url = `${API_BASE_URL}/users`;
 
     await axios.post(url, user.value);
     dialogCreateAccount.value = false;

--- a/src/pages/Collection.vue
+++ b/src/pages/Collection.vue
@@ -37,6 +37,7 @@ import ProductCard from "../components/ProductCard.vue";
 import { useRoute } from "vue-router";
 import { ref, watch } from "vue";
 import { useI18n } from 'vue-i18n';
+import { API_BASE_URL } from "../constants/api";
 
 const { t } = useI18n();
 
@@ -63,7 +64,7 @@ async function chargeMoreProducts() {
     const idCollection = route.params.id;
     loadingBtn.value = true;
     page.value += 1;
-    const url = `https://platamx-backend-1cvg.onrender.com/products?page=${page.value}&items=8&collestionsIds=${idCollection}`;
+    const url = `${API_BASE_URL}/products?page=${page.value}&items=8&collestionsIds=${idCollection}`;
     const { data: response } = await axios.get(url);
 
     response.data.forEach((e) => {
@@ -79,7 +80,7 @@ async function chargeMoreProducts() {
 
 async function getProductsByCollection(idCollection) {
   try {
-    const url = `https://platamx-backend-1cvg.onrender.com/products?page=${page.value}&items=8&collestionsIds=${idCollection}`;
+    const url = `${API_BASE_URL}/products?page=${page.value}&items=8&collestionsIds=${idCollection}`;
     const { data: response } = await axios.get(url);
     products.value = response.data;
     loading.value = false;

--- a/src/pages/Product.vue
+++ b/src/pages/Product.vue
@@ -161,6 +161,7 @@ import Login from "../components/Login.vue";
 import CreateAccount from "../components/CreateAccount.vue";
 import { apiAuth } from "../boot/axios";
 import { getBackendError } from "../utils/error";
+import { API_BASE_URL } from "../constants/api";
 
 const { t, locale } = useI18n();
 const $q = useQuasar();
@@ -204,7 +205,7 @@ async function getProduct() {
   try {
     loading.value = true;
     const idProduct = route.params.id;
-    const url = `https://platamx-backend-1cvg.onrender.com/products/${idProduct}`;
+    const url = `${API_BASE_URL}/products/${idProduct}`;
 
     const { data: response } = await axios.get(url);
     if (response.data.images.length === 0) {

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -46,6 +46,7 @@ import axios from "axios";
 import { useRoute } from "vue-router";
 import { ref, watch } from "vue";
 import { useI18n } from 'vue-i18n';
+import { API_BASE_URL } from "../constants/api";
 
 const { t } = useI18n();
 
@@ -71,7 +72,7 @@ function init() {
 
 async function getProductsBySearch(search) {
   try {
-    const url = `https://platamx-backend-1cvg.onrender.com/products?page=${page.value}&items=8&find=${search}`;
+    const url = `${API_BASE_URL}/products?page=${page.value}&items=8&find=${search}`;
     const { data: response } = await axios.get(url);
     total.value = response.pagination.total;
     products.value = response.data;
@@ -87,7 +88,7 @@ async function chargeMoreProducts() {
     search.value = route.query.q;
     loadingBtn.value = true;
     page.value += 1;
-    const url = `https://platamx-backend-1cvg.onrender.com/products?page=${page.value}&items=8&find=${search.value}`;
+    const url = `${API_BASE_URL}/products?page=${page.value}&items=8&find=${search.value}`;
     const { data: response } = await axios.get(url);
 
     response.data.forEach((e) => {


### PR DESCRIPTION
Elimina la URL hardcodeada de 13 ocurrencias en 9 archivos y la reemplaza por la constante en src/constants/api.ts.